### PR TITLE
use go1.17 in benchstat

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Benchmark
         run: go test -run=^$ -bench=. -count=5 -timeout=60m ./... | tee -a new.txt
       - name: Upload Benchmark
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
       - name: Benchmark
         run: go test -run=^$ -bench=. -count=5 -timeout=60m ./... | tee -a old.txt
       - name: Upload Benchmark
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
       - name: Install benchstat
         run: go get -u golang.org/x/perf/cmd/benchstat
       - name: Download Incoming


### PR DESCRIPTION
In previous changes from #6, `.github/workflows/build.yml` was updated to require at least go1.17 but `benchstat.yml` was neglected, resulting in issue running bench:

```
29  Error: ../../../go/pkg/mod/github.com/rqlite/go-sqlite3@v1.27.1/sqlite3_opt_serialize.go:41:26: undefined: math.MaxInt
30  note: module requires Go 1.16
```

The problem is that module `github.com/rqlite/go-sqlite3` 
* requires 1.16 in its go.mod
* and also uses `math.MaxInt` that was added in 1.17