### PR TITLE
Fix unmerged changes & import path

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	redisType  = "redis"
-	rqliteType = "rqlite"
-	sqliteType = "sqlite"
+	RedisType  = "redis"
+	RqliteType = "rqlite"
+	SqliteType = "sqlite"
 )
 
 // Task represents a unit of work to be performed.
@@ -204,7 +204,7 @@ const (
 	// TaskStateArchived indicates that the task is archived and stored for inspection purposes.
 	TaskStateArchived
 
-	// Indicates that the task is processed successfully and retained until the retention TTL expires.
+	// TaskStateCompleted indicates that the task is processed successfully and retained until the retention TTL expires.
 	TaskStateCompleted
 )
 

--- a/asynq_test.go
+++ b/asynq_test.go
@@ -100,7 +100,7 @@ type TestContext interface {
 
 func doInitBrokerTypeOnce(tb testing.TB) {
 	initBrokerOnce.Do(func() {
-		if brokerType == sqliteType {
+		if brokerType == SqliteType {
 			rqliteConfig.Type = brokerType
 			if rqliteConfig.SqliteDbPath == "" {
 				if rqliteConfig.SqliteInMemory {
@@ -120,9 +120,9 @@ func doInitBrokerTypeOnce(tb testing.TB) {
 
 func getClientConnOpt(tb testing.TB) ClientConnOpt {
 	switch brokerType {
-	case redisType:
+	case RedisType:
 		return getRedisConnOpt(tb)
-	case rqliteType, sqliteType:
+	case RqliteType, SqliteType:
 		return RqliteConnOpt{Config: rqliteConfig}
 	}
 	tb.Fatal("invalid broker type: " + brokerType)
@@ -134,13 +134,13 @@ func setupTestContext(tb testing.TB) TestContext {
 
 	var ret TestContext
 	switch brokerType {
-	case redisType:
+	case RedisType:
 		opt := getRedisConnOpt(tb)
 		ret = &redisTestContext{
 			tb: tb,
 			r:  opt.MakeClient().(redis.UniversalClient),
 		}
-	case rqliteType, sqliteType:
+	case RqliteType, SqliteType:
 		rqliteConfig.Type = brokerType
 		opt := RqliteConnOpt{Config: rqliteConfig}
 		ret = &rqliteTestContext{

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.2.0
+	github.com/mattn/go-sqlite3 v0.0.0-00010101000000-000000000000
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/rqlite/go-sqlite3 v1.27.1
 	github.com/rqlite/gorqlite v0.0.0-20210804113434-b4935d2eab04
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.7.0
@@ -20,4 +20,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
 
-replace github.com/rqlite/gorqlite => github.com/eluv-io/gorqlite v0.0.6
+replace (
+	github.com/mattn/go-sqlite3 => github.com/rqlite/go-sqlite3 v1.27.1
+	github.com/rqlite/gorqlite => github.com/eluv-io/gorqlite v0.0.6
+)

--- a/inspector.go
+++ b/inspector.go
@@ -38,6 +38,15 @@ func NewInspectorFrom(s *Server) (*Inspector, error) {
 	return newInspector(s.broker), nil
 }
 
+// NewInspectorClient returns a new instance of Inspector built with the broker of
+// the given Client.
+func NewInspectorClient(c *Client) (*Inspector, error) {
+	if c == nil {
+		return nil, errors.E(errors.Op("NewInspectorFrom"), errors.Internal, "client is nil")
+	}
+	return newInspector(c.rdb), nil
+}
+
 func newInspector(c base.Broker) *Inspector {
 	return &Inspector{
 		rdb: c.Inspector(),

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -395,7 +395,7 @@ func TestInspectorGetQueueInfo(t *testing.T) {
 				tc.qname, got, err, tc.want)
 			continue
 		}
-		if brokerType == rqliteType || brokerType == sqliteType {
+		if brokerType == RqliteType || brokerType == SqliteType {
 			if diff := cmp.Diff(tc.wantRqlite, got, timeCmpOpt, ignoreMemUsg); diff != "" {
 				t.Errorf("r.GetQueueInfo(%q) = %v, %v, want %v, nil; (-want, +got)\n%s",
 					tc.qname, got, err, tc.want, diff)
@@ -431,13 +431,13 @@ func TestInspectorHistory(t *testing.T) {
 	}
 
 	processedCount := func(i int) int {
-		if brokerType == rqliteType || brokerType == sqliteType {
+		if brokerType == RqliteType || brokerType == SqliteType {
 			return (i + 1) * 10
 		}
 		return (i + 1) * 1000
 	}
 	failedCount := func(i int) int {
-		if brokerType == rqliteType || brokerType == sqliteType {
+		if brokerType == RqliteType || brokerType == SqliteType {
 			return i + 1
 		}
 		return i + 10

--- a/internal/rqlite/errors.go
+++ b/internal/rqlite/errors.go
@@ -43,14 +43,6 @@ func (e *RqliteError) Error() string {
 
 func (e *RqliteError) Unwrap() error { return e.Err }
 
-func NewRqliteWError(op errors.Op, wr sqlite3.WriteResult, err error, stmt interface{}) error {
-	return &RqliteError{
-		Op:         op,
-		Err:        err,
-		Statements: []StatementError{{Error: wr.Err, Statement: stmt}},
-	}
-}
-
 func NewRqliteWsError(op errors.Op, wrs []sqlite3.WriteResult, err error, stmts []*sqlite3.Statement) error {
 	statements := make([]StatementError, 0)
 	for ndx, wr := range wrs {
@@ -62,14 +54,6 @@ func NewRqliteWsError(op errors.Op, wrs []sqlite3.WriteResult, err error, stmts 
 		Op:         op,
 		Err:        err,
 		Statements: statements,
-	}
-}
-
-func NewRqliteRError(op errors.Op, qr sqlite3.QueryResult, err error, stmt interface{}) error {
-	return &RqliteError{
-		Op:         op,
-		Err:        err,
-		Statements: []StatementError{{Error: qr.Err(), Statement: stmt}},
 	}
 }
 

--- a/internal/rqlite/queues.go
+++ b/internal/rqlite/queues.go
@@ -26,7 +26,7 @@ func (conn *Connection) EnsureQueue(queue string) error {
 	st := conn.ensureQueueStatement(queue)
 	wrs, err := conn.WriteStmt(conn.ctx(), st)
 	if err != nil {
-		return NewRqliteWError("EnsureQueue", wrs[0], err, st)
+		return NewRqliteWsError("EnsureQueue", wrs, err, []*sqlite3.Statement{st})
 	}
 	return nil
 }
@@ -39,7 +39,7 @@ func (conn *Connection) GetQueue(qname string) (*queueRow, error) {
 		qname)
 	qrs, err := conn.QueryStmt(conn.ctx(), st)
 	if err != nil {
-		return nil, NewRqliteRError("getQueue", qrs[0], err, st)
+		return nil, NewRqliteRsError(op, qrs, err, []*sqlite3.Statement{st})
 	}
 	if len(qrs) == 0 || qrs[0].NumRows() == 0 {
 		return nil, nil
@@ -71,7 +71,7 @@ func (conn *Connection) pauseQueue(queue string, b bool) error {
 		val)
 	wrs, err := conn.WriteStmt(conn.ctx(), st)
 	if err != nil {
-		return NewRqliteWError(op, wrs[0], err, st)
+		return NewRqliteWsError(op, wrs, err, []*sqlite3.Statement{st})
 	}
 	switch wrs[0].RowsAffected {
 	case 1:
@@ -143,7 +143,7 @@ func (conn *Connection) listQueues(queue ...string) ([]*queueRow, error) {
 
 	qrs, err := conn.QueryStmt(conn.ctx(), st)
 	if err != nil {
-		return nil, NewRqliteRError(op, qrs[0], err, st)
+		return nil, NewRqliteRsError(op, qrs, err, []*sqlite3.Statement{st})
 	}
 
 	qr := qrs[0]

--- a/internal/rqlite/rqlite.go
+++ b/internal/rqlite/rqlite.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hibiken/asynq/internal/base"
 	"github.com/hibiken/asynq/internal/errors"
 	"github.com/hibiken/asynq/internal/log"
+	"github.com/hibiken/asynq/internal/sqlite3"
 	"github.com/hibiken/asynq/internal/timeutil"
 )
 
@@ -607,7 +608,8 @@ func (r *RQLite) CancelationPubSub() (base.PubSub, error) {
 					uuid)
 				wrs, err := conn.WriteStmt(r.context(), st)
 				if err != nil {
-					r.logger.Error(fmt.Sprintf("cancellation channel delete failed: %v", NewRqliteWError(op, wrs[0], err, st)))
+					r.logger.Error(fmt.Sprintf("cancellation channel delete failed: %v",
+						NewRqliteWsError(op, wrs, err, []*sqlite3.Statement{st})))
 				}
 
 			}
@@ -631,7 +633,7 @@ func (r *RQLite) PublishCancelation(id string) error {
 		r.Now().Unix())
 	wrs, err := conn.WriteStmt(r.context(), st)
 	if err != nil {
-		return NewRqliteWError(op, wrs[0], err, st)
+		return NewRqliteWsError(op, wrs, err, []*sqlite3.Statement{st})
 	}
 	return nil
 }

--- a/internal/rqlite/scheduler.go
+++ b/internal/rqlite/scheduler.go
@@ -27,7 +27,7 @@ func (conn *Connection) listSchedulerEntries(where string, whereParams ...interf
 
 	qrs, err := conn.QueryStmt(conn.ctx(), st)
 	if err != nil {
-		return nil, NewRqliteRError(op, qrs[0], err, st)
+		return nil, NewRqliteRsError(op, qrs, err, []*sqlite3.Statement{st})
 	}
 
 	qr := qrs[0]
@@ -107,7 +107,7 @@ func (conn *Connection) listSchedulerEnqueueEvents(entryID string, page base.Pag
 
 	qrs, err := conn.QueryStmt(conn.ctx(), st)
 	if err != nil {
-		return nil, NewRqliteRError(op, qrs[0], err, st)
+		return nil, NewRqliteRsError(op, qrs, err, []*sqlite3.Statement{st})
 	}
 	return parseSchedulerEnqueueEvents(qrs[0])
 }
@@ -122,7 +122,7 @@ func (conn *Connection) listAllSchedulerEnqueueEvents(entryID string) ([]*schedu
 
 	qrs, err := conn.QueryStmt(conn.ctx(), st)
 	if err != nil {
-		return nil, NewRqliteRError(op, qrs[0], err, st)
+		return nil, NewRqliteRsError(op, qrs, err, []*sqlite3.Statement{st})
 	}
 	return parseSchedulerEnqueueEvents(qrs[0])
 }
@@ -169,7 +169,7 @@ func (conn *Connection) clearSchedulerEntries(schedulerID string) error {
 		schedulerID)
 	wrs, err := conn.WriteStmt(conn.ctx(), stmt)
 	if err != nil {
-		return NewRqliteWError(op, wrs[0], err, stmt)
+		return NewRqliteWsError(op, wrs, err, []*sqlite3.Statement{stmt})
 	}
 	return nil
 }
@@ -179,7 +179,7 @@ func (conn *Connection) clearSchedulerHistory(entryID string) error {
 		entryID)
 	wrs, err := conn.WriteStmt(conn.ctx(), stmt)
 	if err != nil {
-		return NewRqliteWError("rqlite.clearSchedulerHistory", wrs[0], err, stmt)
+		return NewRqliteWsError("rqlite.clearSchedulerHistory", wrs, err, []*sqlite3.Statement{stmt})
 	}
 	return nil
 }

--- a/internal/rqlite/server.go
+++ b/internal/rqlite/server.go
@@ -36,7 +36,7 @@ func (conn *Connection) listServers(where string, whereParams ...interface{}) ([
 
 	qrs, err := conn.QueryStmt(conn.ctx(), st)
 	if err != nil {
-		return nil, NewRqliteRError(op, qrs[0], err, st)
+		return nil, NewRqliteRsError(op, qrs, err, []*sqlite3.Statement{st})
 	}
 
 	qr := qrs[0]
@@ -94,7 +94,7 @@ func (conn *Connection) listWorkers(where string, whereParams ...interface{}) ([
 
 	qrs, err := conn.QueryStmt(conn.ctx(), st)
 	if err != nil {
-		return nil, NewRqliteRError(op, qrs[0], err, st)
+		return nil, NewRqliteRsError(op, qrs, err, []*sqlite3.Statement{st})
 	}
 
 	qr := qrs[0]

--- a/internal/sqlite3/db/db.go
+++ b/internal/sqlite3/db/db.go
@@ -41,7 +41,7 @@ var stats *expvar.Map
 func init() {
 	rand.Seed(time.Now().UnixNano())
 	DBVersion, _, _ = sqlite3.Version()
-	stats = expvar.NewMap("db")
+	stats = expvar.NewMap("asynq_db")
 	ResetStats()
 }
 

--- a/internal/sqlite3/db/db.go
+++ b/internal/sqlite3/db/db.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq/internal/sqlite3/command"
-	"github.com/rqlite/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 )
 
 const bkDelay = 250

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -88,7 +88,7 @@ func TestSchedulerRegister(t *testing.T) {
 }
 
 func TestSchedulerWhenRedisDown(t *testing.T) {
-	if brokerType == rqliteType || brokerType == sqliteType {
+	if brokerType == RqliteType || brokerType == SqliteType {
 		t.Skip("redis specific test")
 	}
 


### PR DESCRIPTION
* fix unmerged changes in Client
* export conn types
* avoid panic when initializing db since `expvar.NewMap("db")` is already used from another module
* use replacement for go-sqlite3 (see [rqlite/pull/2](https://github.com/eluv-io/rqlite/pull/2))

otherwise when importing in fabric:
```
$ go mod tidy
go: github.com/rqlite/go-sqlite3@v1.27.1 used for two different module paths (github.com/mattn/go-sqlite3 and github.com/rqlite/go-sqlite3)
``` 