### PR TITLE
Add TaskCanceled to separate user cancelation from context cancelation

### DIFF
--- a/inspector_test.go
+++ b/inspector_test.go
@@ -3345,7 +3345,7 @@ func TestInspectorCancelProcessing(t *testing.T) {
 
 	am1 := &base.TaskMessage{}
 	*am1 = *m1
-	am1.ErrorMsg = context.Canceled.Error()
+	am1.ErrorMsg = TaskCanceled.Error()
 	am1.LastFailedAt = lfa.Unix()
 
 	client := NewClient(getClientConnOpt(t))

--- a/processor_test.go
+++ b/processor_test.go
@@ -366,7 +366,7 @@ func TestProcessorContextDoneWithAsyncTasks(t *testing.T) {
 		for n, m := range tc.wantArchived {
 			am := &base.TaskMessage{}
 			*am = *m
-			am.ErrorMsg = context.Canceled.Error()
+			am.ErrorMsg = TaskCanceled.Error()
 			am.LastFailedAt = lfa
 			tc.wantArchived[n] = am
 		}


### PR DESCRIPTION
Incidentally, `asynq` uses `context.Context` to handle user-initiated cancelations and server-related cancelations (e.g. server shutdown). A previous change (#15) updated the error handling to archive tasks upon context cancelation (instead of changing to retry state), but this had the effect of archiving tasks in the event of a server shutdown, which is incorrect and undesired behavior

Instead, this change adds `asynq.TaskCanceled` and additional processing in order to handle user-initiated cancelations differently from context cancelations. `TaskCanceled` would be used in two ways:
- Cancelations through `Inspector.CancelProcessing()` (and the Subscriber) will submit `TaskCanceled` on behalf of the task handler to the processor
- The task handler may decide to return a wrapped `TaskCanceled` to force `asynq` to immediately archive the task without retrying. Effectively, this is the same behavior as returning a wrapped `SkipRetry` but just with a more informative error description