### PR TITLE
sqlite: fix error 'database is locked'

### DIFF
--- a/asynq_end2end_sqlite_test.go
+++ b/asynq_end2end_sqlite_test.go
@@ -1,0 +1,230 @@
+package asynq
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"reflect"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestLocalLongRun(t *testing.T) {
+	// To execute this manually uncomment this line
+	//brokerType = SqliteType
+
+	if testing.Short() || brokerType != SqliteType {
+		// test takes 1 or 2 minutes
+		t.Skip("long run (1m) with sqlite")
+	}
+
+	dir, err := os.MkdirTemp("", "testLocalLongRun")
+	require.NoError(t, err)
+	cleanup := func() {
+		_ = os.RemoveAll(dir)
+	}
+	defer cleanup()
+
+	dbPath := fmt.Sprintf("%s/db.sqlite", dir)
+	fmt.Println("db_path", dbPath)
+
+	rqliteConfig.TablesPrefix = "local_"
+	rqliteConfig.SqliteDbPath = dbPath
+	rqliteConfig.Type = "sqlite"
+
+	client := NewClient(getClientConnOpt(t))
+	srv := newServer(client.rdb, Config{
+		ServerID:    "inod1111",
+		Concurrency: 10,
+		RetryDelayFunc: func(n int, err error, t *Task) time.Duration {
+			return time.Millisecond * 200
+		},
+		LogLevel:             InfoLevel,
+		ProcessorEmptyQSleep: time.Millisecond * 200,
+		ShutdownTimeout:      time.Millisecond * 10,
+		HealthCheckInterval:  time.Millisecond * 200,
+		ForwarderInterval:    time.Millisecond * 200,
+		Queues: &QueuesConfig{
+			Queues: map[string]int{
+				"low":    1,
+				"normal": 3,
+				"high":   5,
+			},
+		},
+	})
+
+	mux := NewServeMux()
+	_ = srv.Start(mux)
+	defer srv.Stop()
+
+	inspector := newInspector(srv.broker)
+
+	log := srv.logger
+	handled := atomic.NewInt64(0)
+	startCh := make(chan struct{})
+	done := atomic.NewBool(false)
+	doneCh := make(chan struct{})
+
+	handleError := func(err error) {
+		if err == nil {
+			return
+		}
+		serr := err.Error()
+		log.Warnf("error: %v, type: %v", serr, reflect.TypeOf(err))
+		if !strings.Contains(serr, "database is locked") {
+			return
+		}
+		log.Warnf("full stack dump - stacktraces %s", "\n"+string(debug.Stack()))
+		if !done.Load() {
+			done.Store(true)
+			close(doneCh)
+		}
+	}
+
+	readTask := func(task *Task) error {
+		id := string(task.Payload())
+		queue := task.Type()
+		_, err := inspector.GetTaskInfo(queue, id)
+		return err
+	}
+
+	mux.HandleFunc(
+		"normal",
+		func(ctx context.Context, task *Task) error {
+			c := handled.Inc()
+
+			errr := readTask(task)
+			handleError(errr)
+
+			time.Sleep(time.Millisecond * 250)
+			wa := task.ResultWriter()
+
+			bb := binary.LittleEndian.AppendUint64(nil, uint64(c))
+			_, errw := wa.Write(bb)
+			handleError(errw)
+
+			if c%10 == 0 {
+				log.Infof("handled: %d (task: %s)", c, string(task.Payload()))
+			}
+
+			return nil
+
+		})
+	require.NoError(t, err)
+	mux.HandleFunc(
+		"high",
+		func(ctx context.Context, task *Task) error {
+			errr := readTask(task)
+			handleError(errr)
+
+			wa := task.ResultWriter()
+			_, errw := wa.Write([]byte("b"))
+			handleError(errw)
+
+			c := handled.Inc()
+			if c%10 == 0 {
+				log.Infof("handled count: %d (task: %s)", c, string(task.Payload()))
+			}
+
+			return nil
+		})
+	require.NoError(t, err)
+
+	w := time.Now()
+	enqueued := atomic.NewInt64(0)
+	execDuration := time.Minute * 2
+	go func() {
+		iter := 0
+
+		for time.Now().Sub(w) < execDuration && enqueued.Load() <= 20000 {
+			if iter == 5 {
+				close(startCh)
+			}
+
+			c := handled.Load()
+			switch c % 3 {
+			case 0:
+			case 1:
+				time.Sleep(time.Millisecond * 300)
+			case 2:
+				time.Sleep(time.Millisecond * 600)
+			}
+			id := fmt.Sprintf("a-%d", iter)
+			_, err := client.EnqueueContext(
+				context.Background(),
+				NewTask("normal", []byte(id)),
+				Queue("normal"),
+				MaxRetry(1),
+				ReprocessAfter(time.Millisecond*250),
+				Timeout(time.Hour),
+				TaskID(id),
+				Retention(time.Hour))
+			handleError(err)
+			if err != nil {
+				break
+			}
+			enqueued.Inc()
+			id = fmt.Sprintf("b-%d", iter)
+			_, err = client.EnqueueContext(
+				context.Background(),
+				NewTask("high", []byte(id)),
+				Queue("high"),
+				Timeout(time.Millisecond*150),
+				TaskID(id),
+				Retention(time.Hour))
+			handleError(err)
+			if err != nil {
+				break
+			}
+			enqueued.Inc()
+			iter++
+			if iter%100 == 0 {
+				log.Infof("enqueue - iter count: %d", iter)
+			}
+			select {
+			case <-doneCh:
+				break
+			default:
+			}
+		}
+		log.Infof("<< finished enqueuing - took %v, iter: %d, enqueued: %d, handled: %d", time.Now().Sub(w),
+			iter,
+			enqueued.Load(),
+			handled.Load())
+		if !done.Load() {
+			done.Store(true)
+			close(doneCh)
+		}
+	}()
+
+	<-startCh
+	ticker := time.NewTicker(time.Second * 10)
+out:
+	for {
+		select {
+		case <-doneCh:
+			break out
+		case <-ticker.C:
+			enq := enqueued.Load()
+			han := handled.Load()
+			log.Infof("queue - d: %v, enqueued: %d, handled: %d",
+				time.Now().Sub(w),
+				enq,
+				han)
+			if enq == han && enq >= 1000 {
+				break out
+			}
+		}
+	}
+
+	log.Infof("<< queue closing - took: %v, enqueued: %d, handled: %d",
+		time.Now().Sub(w),
+		enqueued.Load(),
+		handled.Load())
+}

--- a/internal/sqlite/conn_sqlite.go
+++ b/internal/sqlite/conn_sqlite.go
@@ -24,5 +24,5 @@ func NewSQLiteConnection(ctx context.Context, dbPath string, inMemory bool) (*sq
 	if err != nil {
 		return nil, errors.E(op, errors.Internal, err)
 	}
-	return sqlite3.NewSQLiteConnection(conn), nil
+	return sqlite3.NewSQLiteConnection(conn, true), nil
 }

--- a/internal/sqlite3/db/db.go
+++ b/internal/sqlite3/db/db.go
@@ -90,7 +90,11 @@ func Open(dbPath string, fkEnabled bool) (*DB, error) {
 // OpenContext opens a file-based database, creating it if it does not exist.
 // After this function returns, an actual SQLite file will always exist.
 func OpenContext(ctx context.Context, dbPath string, fkEnabled bool) (*DB, error) {
-	rwDSN := fmt.Sprintf("file:%s?_fk=%s", dbPath, strconv.FormatBool(fkEnabled))
+	rwOpts := []string{
+		"_txlock=immediate",
+		fmt.Sprintf("_fk=%s", strconv.FormatBool(fkEnabled)),
+	}
+	rwDSN := fmt.Sprintf("file:%s?%s", dbPath, strings.Join(rwOpts, "&"))
 	rwDB, err := sql.Open("sqlite3", rwDSN)
 	if err != nil {
 		return nil, err
@@ -98,9 +102,9 @@ func OpenContext(ctx context.Context, dbPath string, fkEnabled bool) (*DB, error
 
 	roOpts := []string{
 		"mode=ro",
+		"_txlock=deferred",
 		fmt.Sprintf("_fk=%s", strconv.FormatBool(fkEnabled)),
 	}
-
 	roDSN := fmt.Sprintf("file:%s?%s", dbPath, strings.Join(roOpts, "&"))
 	roDB, err := sql.Open("sqlite3", roDSN)
 	if err != nil {


### PR DESCRIPTION
The fix add retries for the case where multiple connections are used simultaneously and uses a mutex for multiple write calls made concurrently with a single `SQLiteConnection` (note that the code in the fabric uses a single connection for the server, the client and the inspector).

* use option `_txlock=immediate` when opening a read-write connection in `db.DB`. See: 
   * `IMMEDIATE` in [sqlite doc for transaction](https://www.sqlite.org/lang_transaction.html) 
   * `_txlock` in [go-sqlite3 doc](https://github.com/mattn/go-sqlite3#connection-string)
   * this [comment in #607 of go-sqlite3](https://github.com/mattn/go-sqlite3/issues/607#issuecomment-808739698)
* add lock around `SQLiteConnection.Execute`
* add retries for error `sqlite_busy` (when using multiple connections). see [SQLITE_BUSY in sqlite doc](https://www.sqlite.org/rescode.html#busy)
* improve rqlite errors by reporting the caller

---

sample error messages found in logs

```
2023-05-23T19:37:37.642Z DEBUG enqueue errors: rqlite.enqueueMessages 
  - rqlite error: unexpected result count: 1, expected: 2  -> database is locked "INSERT INTO ltaskq_asynq_queues (queue_name, state) VALUES(dist:livepart, 'active')  ON CONFLICT(queue_name) DO NOTHING;", state: pending, type: dist:livepart, id: hqt_CUZL75rJyNh2vXWrSGLemQeBaEaJXHpKr44rPvVT logger=/store/localTaskq gid=9435900

2023-05-23T19:39:42.915Z WARN  Could not move task id=hqt_9PXGZrwAkWCYDYdduxYq5tAEjXhRz8GUngcNShHD:inod21LrUiai85M8hq24yana53KNdY9i 
  type="dist:livenode" from "asynq:{dist:livenode}:active" to "asynq:{dist:livenode}:completed":  rqlite.setTaskCompleted: NOT_FOUND: error 
  (UPDATE ltaskq_asynq_tasks SET state=completed, task_msg=0a0d6...8f9acb4a306, deadline=NULL, sid=inodKnnpcZjRT65FLteMrULXBme4xS9, done_at=1684870777, cleanup_at=1692646777, retain_until=1687462777 WHERE task_uuid=hqt_9PXGZrwAkWCYDYdduxYq5tAEjXhRz8GUngcNShHD:inod21LrUiai85M8hq24yana53KNdY9i AND state='active'): 
  database is locked; Will retry syncing logger=/store/localTaskq gid=9438871
```
