### PR TITLE
add 'after' hook to execute after task state change

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -38,9 +38,9 @@ func BenchmarkEndToEndSimple(b *testing.B) {
 
 		srv := newServer(client.rdb, Config{
 			Concurrency: 10,
-			RetryDelayFunc: func(n int, err error, t *Task) time.Duration {
+			RetryDelayFunc: RetryDelayFunc(func(n int, err error, t *Task) time.Duration {
 				return time.Second
-			},
+			}),
 			LogLevel: testLogLevel,
 		})
 		// Create a bunch of tasks
@@ -80,9 +80,9 @@ func BenchmarkEndToEnd(b *testing.B) {
 		client := NewClient(getClientConnOpt(b))
 		srv := newServer(client.rdb, Config{
 			Concurrency: 10,
-			RetryDelayFunc: func(n int, err error, t *Task) time.Duration {
+			RetryDelayFunc: RetryDelayFunc(func(n int, err error, t *Task) time.Duration {
 				return time.Second
-			},
+			}),
 			LogLevel: testLogLevel,
 		})
 		// Create a bunch of tasks
@@ -210,9 +210,9 @@ func BenchmarkClientWhileServerRunning(b *testing.B) {
 		client := NewClient(getClientConnOpt(b))
 		srv := newServer(client.rdb, Config{
 			Concurrency: 10,
-			RetryDelayFunc: func(n int, err error, t *Task) time.Duration {
+			RetryDelayFunc: RetryDelayFunc(func(n int, err error, t *Task) time.Duration {
 				return time.Second
-			},
+			}),
 			LogLevel: testLogLevel,
 		})
 		// Enqueue 10,000 tasks.

--- a/errmux.go
+++ b/errmux.go
@@ -1,0 +1,44 @@
+package asynq
+
+import "context"
+
+type ErrorMux struct {
+	taskMatcher *TaskMatcher[ErrorHandler]
+	defHandler  func() ErrorHandler
+}
+
+func NewErrorMux(defaultHandler ErrorHandler) *ErrorMux {
+	def := noErrorHandler
+	if defaultHandler != nil {
+		def = func() ErrorHandler { return defaultHandler }
+	}
+	return &ErrorMux{
+		taskMatcher: NewTaskMatcher[ErrorHandler](),
+		defHandler:  def,
+	}
+}
+
+func (mux *ErrorMux) HandleError(ctx context.Context, task *Task, err error) {
+	h, _ := mux.Handler(task)
+	h.HandleError(ctx, task, err)
+}
+
+func (mux *ErrorMux) Handler(t *Task) (h ErrorHandler, pattern string) {
+	return mux.taskMatcher.Handler(t, mux.defHandler)
+}
+
+func (mux *ErrorMux) Handle(pattern string, handler ErrorHandler) {
+	mux.taskMatcher.Handle(pattern, handler)
+}
+
+func (mux *ErrorMux) HandleFunc(pattern string, handler func(context.Context, *Task, error)) {
+	if handler == nil {
+		panic("asynq: nil error handler")
+	}
+	mux.Handle(pattern, ErrorHandlerFunc(handler))
+}
+
+// noErrorHandler returns a noop error handler.
+func noErrorHandler() ErrorHandler {
+	return ErrorHandlerFunc(func(ctx context.Context, task *Task, err error) {})
+}

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -3380,9 +3380,9 @@ func TestInspectorCancelProcessing(t *testing.T) {
 
 			server := newServer(client.rdb, Config{
 				Concurrency: 10,
-				RetryDelayFunc: func(n int, err error, t *Task) time.Duration {
+				RetryDelayFunc: RetryDelayFunc(func(n int, err error, t *Task) time.Duration {
 					return time.Second
-				},
+				}),
 				LogLevel:            testLogLevel,
 				HeartBeaterInterval: time.Millisecond * 5,
 			})

--- a/internal/base/after.go
+++ b/internal/base/after.go
@@ -1,0 +1,49 @@
+package base
+
+import "sync"
+
+// AfterTasks is a collection that holds functions called after an active task finishes.
+//
+// AfterTasks are safe for concurrent use by multiple goroutines.
+type AfterTasks struct {
+	mu    sync.Mutex
+	funcs map[string]func(id string, err error, isFailure bool)
+}
+
+// NewAfterTasks returns a AfterTasks instance.
+func NewAfterTasks() *AfterTasks {
+	return &AfterTasks{
+		funcs: make(map[string]func(id string, err error, isFailure bool)),
+	}
+}
+
+// Add adds a new cancel func to the collection.
+func (c *AfterTasks) Add(id string, fn func(id string, err error, isFailure bool)) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.funcs[id] = fn
+}
+
+// Delete deletes a cancel func from the collection given an id.
+func (c *AfterTasks) Delete(id string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.funcs, id)
+}
+
+// Get returns a cancel func given an id.
+func (c *AfterTasks) Get(id string) (fn func(id string, err error, isFailure bool), ok bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	fn, ok = c.funcs[id]
+	return fn, ok
+}

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -661,7 +661,7 @@ func DecodeSchedulerEnqueueEvent(b []byte) (*SchedulerEnqueueEvent, error) {
 
 // Cancelations is a collection that holds cancel functions for all active tasks.
 //
-// Cancelations are safe for concurrent use by multipel goroutines.
+// Cancelations are safe for concurrent use by multiple goroutines.
 type Cancelations struct {
 	mu          sync.Mutex
 	cancelFuncs map[string]context.CancelFunc

--- a/processor.go
+++ b/processor.go
@@ -43,8 +43,8 @@ type processor struct {
 
 	queues Queues
 
-	retryDelayFunc RetryDelayFunc
-	isFailureFunc  func(error) bool
+	retryDelay    RetryDelayHandler
+	isFailureFunc func(error) bool
 
 	errHandler ErrorHandler
 
@@ -80,6 +80,9 @@ type processor struct {
 	// cancelations is a set of cancel functions for all active tasks.
 	cancelations *base.Cancelations
 
+	// after is a set of function set by active tasks to be called after task execution
+	after *base.AfterTasks
+
 	starting chan<- *workerInfo
 	finished chan<- *base.TaskMessage
 
@@ -90,10 +93,11 @@ type processorParams struct {
 	logger          *log.Logger
 	serverID        string
 	broker          base.Broker
-	retryDelayFunc  RetryDelayFunc
+	retryDelayFunc  RetryDelayHandler
 	isFailureFunc   func(error) bool
 	syncCh          chan<- *syncRequest
 	cancelations    *base.Cancelations
+	after           *base.AfterTasks
 	concurrency     int // currently limited to 32767; see processor.fini()
 	queues          Queues
 	errHandler      ErrorHandler
@@ -118,10 +122,11 @@ func newProcessor(params processorParams) *processor {
 		serverID:        params.serverID,
 		broker:          params.broker,
 		queues:          params.queues,
-		retryDelayFunc:  params.retryDelayFunc,
+		retryDelay:      params.retryDelayFunc,
 		isFailureFunc:   params.isFailureFunc,
 		syncRequestCh:   params.syncCh,
 		cancelations:    params.cancelations,
+		after:           params.after,
 		errLogLimiter:   rate.NewLimiter(rate.Every(3*time.Second), 1),
 		sema:            make(chan struct{}, params.concurrency),
 		done:            make(chan struct{}),
@@ -263,7 +268,7 @@ func (p *processor) exec() {
 			ap.mutex.Lock()
 			go func() {
 				defer ap.mutex.Unlock()
-				task := newTask(msg.Type, msg.Payload, rw, ap)
+				task := newTask(msg.Type, msg.Payload, rw, ap, func(fn func(string, error, bool)) { p.after.Add(msg.ID, fn) })
 				resCh <- p.perform(ctx, task)
 			}()
 			// finish task processing in p.fini() goroutine to allow this goroutine to end
@@ -454,6 +459,13 @@ func (p *processor) requeueAborting(msg *base.TaskMessage) {
 	}
 }
 
+func (p *processor) taskFinished(msg *base.TaskMessage, err error, isFailure bool) {
+	if fn, ok := p.after.Get(msg.ID); ok {
+		fn(msg.ID, err, isFailure)
+		p.after.Delete(msg.ID)
+	}
+}
+
 func (p *processor) handleSucceededMessage(ctx context.Context, msg *base.TaskMessage) {
 	if msg.Retention > 0 {
 		p.markAsComplete(ctx, msg)
@@ -463,7 +475,14 @@ func (p *processor) handleSucceededMessage(ctx context.Context, msg *base.TaskMe
 }
 
 func (p *processor) markAsComplete(ctx context.Context, msg *base.TaskMessage) {
-	err := p.broker.MarkAsComplete(p.serverID, msg)
+	markAsComplete := func() error {
+		err := p.broker.MarkAsComplete(p.serverID, msg)
+		if err == nil {
+			p.taskFinished(msg, nil, false)
+		}
+		return err
+	}
+	err := markAsComplete()
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not move task id=%s type=%q from %q to %q:  %+v",
 			msg.ID, msg.Type, base.ActiveKey(msg.Queue), base.CompletedKey(msg.Queue), err)
@@ -474,7 +493,7 @@ func (p *processor) markAsComplete(ctx context.Context, msg *base.TaskMessage) {
 		p.logger.Warnf("%s; Will retry syncing", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
-				return p.broker.MarkAsComplete(p.serverID, msg)
+				return markAsComplete()
 			},
 			errMsg:   errMsg,
 			deadline: deadline,
@@ -483,7 +502,15 @@ func (p *processor) markAsComplete(ctx context.Context, msg *base.TaskMessage) {
 }
 
 func (p *processor) markAsDone(ctx context.Context, msg *base.TaskMessage) {
-	err := p.broker.Done(p.serverID, msg)
+	markAsDone := func() error {
+		err := p.broker.Done(p.serverID, msg)
+		if err == nil {
+			p.taskFinished(msg, nil, false)
+		}
+		return err
+	}
+
+	err := markAsDone()
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not remove task id=%s type=%q from %q err: %+v", msg.ID, msg.Type, base.ActiveKey(msg.Queue), err)
 		deadline, ok := ctx.Deadline()
@@ -493,7 +520,7 @@ func (p *processor) markAsDone(ctx context.Context, msg *base.TaskMessage) {
 		p.logger.Warnf("%s; Will retry syncing", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
-				return p.broker.Done(p.serverID, msg)
+				return markAsDone()
 			},
 			errMsg:   errMsg,
 			deadline: deadline,
@@ -528,9 +555,18 @@ func (p *processor) retry(ctx context.Context, msg *base.TaskMessage, e error, i
 	if msg.Recurrent {
 		retried = 0
 	}
-	d := p.retryDelayFunc(retried, e, NewTask(msg.Type, msg.Payload))
+	d := p.retryDelay.RetryDelay(retried, e, NewTask(msg.Type, msg.Payload))
 	retryAt := time.Now().Add(d)
-	err := p.broker.Retry(msg, retryAt, e.Error(), isFailure)
+
+	retry := func() error {
+		err := p.broker.Retry(msg, retryAt, e.Error(), isFailure)
+		if err == nil {
+			p.taskFinished(msg, e, isFailure)
+		}
+		return err
+	}
+
+	err := retry()
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not move task id=%s from %q to %q: %+v", msg.ID, base.ActiveKey(msg.Queue), base.RetryKey(msg.Queue), err)
 		deadline, ok := ctx.Deadline()
@@ -540,7 +576,7 @@ func (p *processor) retry(ctx context.Context, msg *base.TaskMessage, e error, i
 		p.logger.Warnf("%s; Will retry syncing", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
-				return p.broker.Retry(msg, retryAt, e.Error(), isFailure)
+				return retry()
 			},
 			errMsg:   errMsg,
 			deadline: deadline,
@@ -549,7 +585,15 @@ func (p *processor) retry(ctx context.Context, msg *base.TaskMessage, e error, i
 }
 
 func (p *processor) archive(ctx context.Context, msg *base.TaskMessage, e error) {
-	err := p.broker.Archive(msg, e.Error())
+	archive := func() error {
+		err := p.broker.Archive(msg, e.Error())
+		if err == nil {
+			p.taskFinished(msg, e, true)
+		}
+		return err
+	}
+
+	err := archive()
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not move task id=%s from %q to %q: %+v", msg.ID, base.ActiveKey(msg.Queue), base.ArchivedKey(msg.Queue), err)
 		deadline, ok := ctx.Deadline()
@@ -559,7 +603,7 @@ func (p *processor) archive(ctx context.Context, msg *base.TaskMessage, e error)
 		p.logger.Warnf("%s; Will retry syncing", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
-				return p.broker.Archive(msg, e.Error())
+				return archive()
 			},
 			errMsg:   errMsg,
 			deadline: deadline,

--- a/recoverer_test.go
+++ b/recoverer_test.go
@@ -234,7 +234,7 @@ func TestRecoverer(t *testing.T) {
 			broker:         client.rdb,
 			queues:         (&QueuesConfig{Queues: map[string]int{"default": 1, "critical": 1}}).configure(),
 			interval:       1 * time.Second,
-			retryDelayFunc: func(n int, err error, task *Task) time.Duration { return 30 * time.Second },
+			retryDelayFunc: RetryDelayFunc(func(n int, err error, task *Task) time.Duration { return 30 * time.Second }),
 			isFailureFunc:  defaultIsFailureFunc,
 		})
 

--- a/retrymux.go
+++ b/retrymux.go
@@ -1,0 +1,46 @@
+package asynq
+
+import (
+	"time"
+)
+
+type RetryMux struct {
+	taskMatcher *TaskMatcher[RetryDelayHandler]
+	defHandler  func() RetryDelayHandler
+}
+
+func NewRetryMux(defaultRetry RetryDelayHandler) *RetryMux {
+	def := noRetryHandler
+	if defaultRetry != nil {
+		def = func() RetryDelayHandler { return defaultRetry }
+	}
+	return &RetryMux{
+		taskMatcher: NewTaskMatcher[RetryDelayHandler](),
+		defHandler:  def,
+	}
+}
+
+func (mux *RetryMux) RetryDelay(n int, e error, task *Task) time.Duration {
+	h, _ := mux.Handler(task)
+	return h.RetryDelay(n, e, task)
+}
+
+func (mux *RetryMux) Handler(t *Task) (h RetryDelayHandler, pattern string) {
+	return mux.taskMatcher.Handler(t, mux.defHandler)
+}
+
+func (mux *RetryMux) Handle(pattern string, handler RetryDelayHandler) {
+	mux.taskMatcher.Handle(pattern, handler)
+}
+
+func (mux *RetryMux) HandleFunc(pattern string, handler func(n int, e error, task *Task) time.Duration) {
+	if handler == nil {
+		panic("asynq: nil retry handler")
+	}
+	mux.Handle(pattern, RetryDelayFunc(handler))
+}
+
+// noRetryHandler returns the default retry delay func.
+func noRetryHandler() RetryDelayHandler {
+	return DefaultRetryDelay
+}

--- a/servemux.go
+++ b/servemux.go
@@ -7,9 +7,6 @@ package asynq
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
-	"sync"
 )
 
 // ServeMux is a multiplexer for asynchronous tasks.
@@ -23,15 +20,7 @@ import (
 // "images:thumbnails" and the former will receive tasks with type name beginning
 // with "images".
 type ServeMux struct {
-	mu  sync.RWMutex
-	m   map[string]muxEntry
-	es  []muxEntry // slice of entries sorted from longest to shortest.
-	mws []MiddlewareFunc
-}
-
-type muxEntry struct {
-	h       Handler
-	pattern string
+	taskMatcher *TaskMatcher[Handler]
 }
 
 // MiddlewareFunc is a function which receives an asynq.Handler and returns another asynq.Handler.
@@ -41,7 +30,7 @@ type MiddlewareFunc func(Handler) Handler
 
 // NewServeMux allocates and returns a new ServeMux.
 func NewServeMux() *ServeMux {
-	return new(ServeMux)
+	return &ServeMux{taskMatcher: NewTaskMatcher[Handler]()}
 }
 
 // ProcessTask dispatches the task to the handler whose
@@ -59,76 +48,13 @@ func (mux *ServeMux) ProcessTask(ctx context.Context, task *Task) error {
 // If there is no registered handler that applies to the task,
 // handler returns a 'not found' handler which returns an error.
 func (mux *ServeMux) Handler(t *Task) (h Handler, pattern string) {
-	mux.mu.RLock()
-	defer mux.mu.RUnlock()
-
-	h, pattern = mux.match(t.Type())
-	if h == nil {
-		h, pattern = NotFoundHandler(), ""
-	}
-	for i := len(mux.mws) - 1; i >= 0; i-- {
-		h = mux.mws[i](h)
-	}
-	return h, pattern
-}
-
-// Find a handler on a handler map given a typename string.
-// Most-specific (longest) pattern wins.
-func (mux *ServeMux) match(typename string) (h Handler, pattern string) {
-	// Check for exact match first.
-	v, ok := mux.m[typename]
-	if ok {
-		return v.h, v.pattern
-	}
-
-	// Check for longest valid match.
-	// mux.es contains all patterns from longest to shortest.
-	for _, e := range mux.es {
-		if strings.HasPrefix(typename, e.pattern) {
-			return e.h, e.pattern
-		}
-	}
-	return nil, ""
-
+	return mux.taskMatcher.Handler(t, NotFoundHandler)
 }
 
 // Handle registers the handler for the given pattern.
 // If a handler already exists for pattern, Handle panics.
 func (mux *ServeMux) Handle(pattern string, handler Handler) {
-	mux.mu.Lock()
-	defer mux.mu.Unlock()
-
-	if strings.TrimSpace(pattern) == "" {
-		panic("asynq: invalid pattern")
-	}
-	if handler == nil {
-		panic("asynq: nil handler")
-	}
-	if _, exist := mux.m[pattern]; exist {
-		panic("asynq: multiple registrations for " + pattern)
-	}
-
-	if mux.m == nil {
-		mux.m = make(map[string]muxEntry)
-	}
-	e := muxEntry{h: handler, pattern: pattern}
-	mux.m[pattern] = e
-	mux.es = appendSorted(mux.es, e)
-}
-
-func appendSorted(es []muxEntry, e muxEntry) []muxEntry {
-	n := len(es)
-	i := sort.Search(n, func(i int) bool {
-		return len(es[i].pattern) < len(e.pattern)
-	})
-	if i == n {
-		return append(es, e)
-	}
-	// we now know that i points at where we want to insert.
-	es = append(es, muxEntry{}) // try to grow the slice in place, any entry works.
-	copy(es[i+1:], es[i:])      // shift shorter entries down.
-	es[i] = e
-	return es
+	mux.taskMatcher.Handle(pattern, handler)
 }
 
 // HandleFunc registers the handler function for the given pattern.
@@ -142,17 +68,14 @@ func (mux *ServeMux) HandleFunc(pattern string, handler func(context.Context, *T
 // Use appends a MiddlewareFunc to the chain.
 // Middlewares are executed in the order that they are applied to the ServeMux.
 func (mux *ServeMux) Use(mws ...MiddlewareFunc) {
-	mux.mu.Lock()
-	defer mux.mu.Unlock()
-	for _, fn := range mws {
-		mux.mws = append(mux.mws, fn)
-	}
+	mux.taskMatcher.UseI(mws)
 }
 
 // NotFound returns an error indicating that the handler was not found for the given task.
 func NotFound(ctx context.Context, task *Task) error {
+	_ = ctx
 	return fmt.Errorf("handler not found for task %q", task.Type())
 }
 
-// NotFoundHandler returns a simple task handler that returns a ``not found`` error.
+// NotFoundHandler returns a simple task handler that returns a “not found“ error.
 func NotFoundHandler() Handler { return HandlerFunc(NotFound) }

--- a/server.go
+++ b/server.go
@@ -390,7 +390,7 @@ func newServer(broker base.Broker, cfg Config) *Server {
 	syncCh := make(chan *syncRequest)
 	state := base.NewServerState()
 	cancels := base.NewCancelations()
-	after := base.NewAfterTasks()
+	afterTasks := base.NewAfterTasks()
 
 	syncer := newSyncer(syncerParams{
 		logger:     logger,
@@ -422,7 +422,7 @@ func newServer(broker base.Broker, cfg Config) *Server {
 		isFailureFunc:   isFailureFunc,
 		syncCh:          syncCh,
 		cancelations:    cancels,
-		after:           after,
+		afterTasks:      afterTasks,
 		concurrency:     n,
 		queues:          cfg.Queues,
 		errHandler:      cfg.ErrorHandler,

--- a/server.go
+++ b/server.go
@@ -66,7 +66,7 @@ type Config struct {
 	// Function to calculate retry delay for a failed task.
 	//
 	// By default, it uses exponential backoff algorithm to calculate the delay.
-	RetryDelayFunc RetryDelayFunc
+	RetryDelayFunc RetryDelayHandler
 
 	// Predicate function to determine whether the error returned from Handler is a failure.
 	// If the function returns false, Server will not increment the retried counter for the task,
@@ -158,7 +158,7 @@ type Config struct {
 	JanitorInterval time.Duration
 }
 
-// An ErrorHandler handles an error occured during task processing.
+// An ErrorHandler handles an error that occurred during task processing.
 type ErrorHandler interface {
 	HandleError(ctx context.Context, task *Task, err error)
 }
@@ -172,6 +172,10 @@ func (fn ErrorHandlerFunc) HandleError(ctx context.Context, task *Task, err erro
 	fn(ctx, task, err)
 }
 
+type RetryDelayHandler interface {
+	RetryDelay(n int, e error, t *Task) time.Duration
+}
+
 // RetryDelayFunc calculates the retry delay duration for a failed task given
 // the retry count, error, and the task.
 //
@@ -179,6 +183,10 @@ func (fn ErrorHandlerFunc) HandleError(ctx context.Context, task *Task, err erro
 // e is the error returned by the task handler.
 // t is the task in question.
 type RetryDelayFunc func(n int, e error, t *Task) time.Duration
+
+func (fn RetryDelayFunc) RetryDelay(n int, e error, t *Task) time.Duration {
+	return fn(n, e, t)
+}
 
 // Logger supports logging at various log levels.
 type Logger interface {
@@ -291,6 +299,8 @@ func DefaultRetryDelayFunc(n int, e error, t *Task) time.Duration {
 	return time.Duration(s) * time.Second
 }
 
+var DefaultRetryDelay = RetryDelayFunc(DefaultRetryDelayFunc)
+
 func defaultIsFailureFunc(err error) bool { return err != nil }
 
 const (
@@ -320,7 +330,7 @@ func newServer(broker base.Broker, cfg Config) *Server {
 	}
 	delayFunc := cfg.RetryDelayFunc
 	if delayFunc == nil {
-		delayFunc = DefaultRetryDelayFunc
+		delayFunc = DefaultRetryDelay
 	}
 	isFailureFunc := cfg.IsFailure
 	if isFailureFunc == nil {
@@ -380,6 +390,7 @@ func newServer(broker base.Broker, cfg Config) *Server {
 	syncCh := make(chan *syncRequest)
 	state := base.NewServerState()
 	cancels := base.NewCancelations()
+	after := base.NewAfterTasks()
 
 	syncer := newSyncer(syncerParams{
 		logger:     logger,
@@ -411,6 +422,7 @@ func newServer(broker base.Broker, cfg Config) *Server {
 		isFailureFunc:   isFailureFunc,
 		syncCh:          syncCh,
 		cancelations:    cancels,
+		after:           after,
 		concurrency:     n,
 		queues:          cfg.Queues,
 		errHandler:      cfg.ErrorHandler,

--- a/task_matcher.go
+++ b/task_matcher.go
@@ -1,0 +1,163 @@
+package asynq
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type TaskMatcher[T any] struct {
+	mu  sync.RWMutex               // protect following fields
+	m   map[string]matcherEntry[T] // exact match
+	es  []matcherEntry[T]          // slice of entries sorted from longest to shortest.
+	mws []func(T) T                // middlewares
+}
+
+type matcherEntry[T any] struct {
+	h       T
+	pattern string
+}
+
+// NewTaskMatcher allocates and returns a new TaskMatcher.
+func NewTaskMatcher[T any]() *TaskMatcher[T] {
+	return new(TaskMatcher[T])
+}
+
+// Handler returns the handler to use for the given task.
+// It always returns a non-nil handler.
+//
+// Handler also returns the registered pattern that matches the task.
+//
+// If there is no registered handler that applies to the task,
+// handler returns the result of calling the notFound parameter.
+func (mux *TaskMatcher[T]) Handler(t *Task, notFound func() T) (h T, pattern string) {
+	if notFound == nil {
+		panic("'notFound' must not be nil")
+	}
+
+	mux.mu.RLock()
+	defer mux.mu.RUnlock()
+
+	h, pattern = mux.match(t.Type())
+	if IsNil(h) {
+		h, pattern = notFound(), ""
+	}
+	h = mux.middleware(h)
+	return h, pattern
+}
+
+func (mux *TaskMatcher[T]) middleware(h T) T {
+	for i := len(mux.mws) - 1; i >= 0; i-- {
+		h = mux.mws[i](h)
+	}
+	return h
+}
+
+// Find a handler on a handler map given a typename string.
+// Most-specific (longest) pattern wins.
+func (mux *TaskMatcher[T]) match(typename string) (h T, pattern string) {
+	// Check for exact match first.
+	v, ok := mux.m[typename]
+	if ok {
+		return v.h, v.pattern
+	}
+
+	// Check for longest valid match.
+	// mux.es contains all patterns from longest to shortest.
+	for _, e := range mux.es {
+		if strings.HasPrefix(typename, e.pattern) {
+			return e.h, e.pattern
+		}
+	}
+	var zero T
+	return zero, ""
+}
+
+// Handle registers the handler for the given pattern.
+// If a handler already exists for pattern, Handle panics.
+func (mux *TaskMatcher[T]) Handle(pattern string, handler T) {
+	mux.mu.Lock()
+	defer mux.mu.Unlock()
+
+	if strings.TrimSpace(pattern) == "" {
+		panic("asynq: invalid pattern")
+	}
+	if IsNil(handler) {
+		panic("asynq: nil handler")
+	}
+	if _, exist := mux.m[pattern]; exist {
+		panic("asynq: multiple registrations for " + pattern)
+	}
+
+	if mux.m == nil {
+		mux.m = make(map[string]matcherEntry[T])
+	}
+	e := matcherEntry[T]{h: handler, pattern: pattern}
+	mux.m[pattern] = e
+	mux.es = mux.appendSorted(mux.es, e)
+}
+
+func (mux *TaskMatcher[T]) appendSorted(es []matcherEntry[T], e matcherEntry[T]) []matcherEntry[T] {
+	n := len(es)
+	i := sort.Search(n, func(i int) bool {
+		return len(es[i].pattern) < len(e.pattern)
+	})
+	if i == n {
+		return append(es, e)
+	}
+	// we now know that i points at where we want to insert.
+	es = append(es, matcherEntry[T]{}) // try to grow the slice in place, any entry works.
+	copy(es[i+1:], es[i:])             // shift shorter entries down.
+	es[i] = e
+	return es
+}
+
+func (mux *TaskMatcher[T]) Use(mws ...func(T) T) {
+	mux.mu.Lock()
+	defer mux.mu.Unlock()
+	for _, fn := range mws {
+		mux.mws = append(mux.mws, fn)
+	}
+}
+
+func (mux *TaskMatcher[T]) UseI(mws interface{}) {
+	k := reflect.TypeOf(mws).Kind()
+	if k != reflect.Slice {
+		// ignore
+		return
+	}
+	mux.mu.Lock()
+	defer mux.mu.Unlock()
+
+	tx := reflect.TypeOf((func(T) T)(nil))
+
+	s := reflect.ValueOf(mws)
+	for i := 0; i < s.Len(); i++ {
+		vfn := s.Index(i)
+		mux.mws = append(mux.mws, vfn.Convert(tx).Interface().(func(T) T))
+	}
+}
+
+var nillableKinds = []reflect.Kind{
+	reflect.Chan, reflect.Func,
+	reflect.Interface, reflect.Map,
+	reflect.Ptr, reflect.Slice}
+
+// IsNil returns true if the given object is nil (== nil) or is a nillable type
+// (channel, function, interface, map, pointer or slice) with a nil value.
+func IsNil(obj interface{}) bool {
+	if obj == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(obj)
+	kind := value.Kind()
+	for _, k := range nillableKinds {
+		if k == kind {
+			return value.IsNil()
+		}
+	}
+
+	return false
+}

--- a/task_matcher_test.go
+++ b/task_matcher_test.go
@@ -1,0 +1,40 @@
+package asynq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatcher(t *testing.T) {
+	nilPrinter := &Printer{path: "nil"}
+	type testCase struct {
+		path     string
+		expected string
+	}
+
+	tm := NewTaskMatcher[*Printer]()
+	handle := func(s string) {
+		tm.Handle(s, &Printer{path: s})
+	}
+	handle("/")
+	handle("/foo/bar")
+	handle("/foo")
+
+	for _, tc := range []*testCase{
+		{path: "/", expected: "/"},
+		{path: "/foo", expected: "/foo"},
+		{path: "/foo/bar", expected: "/foo/bar"},
+		{path: "/foobar", expected: "/foo"},
+		{path: "/xyz", expected: "/"},
+		{path: "xyz", expected: "nil"},
+	} {
+		p, _ := tm.Handler(&Task{typename: tc.path}, func() *Printer { return nilPrinter })
+		require.Equal(t, tc.expected, p.path)
+	}
+
+}
+
+type Printer struct {
+	path string
+}


### PR DESCRIPTION
* Add `CallAfter` hook function to be executed after task execution:

```
// CallAfter enables task processing to schedule execution of a function after the
// task execution. The function is guaranteed to be called once the task state has
// changed in the broker database.
// Function parameter:
// string: task id
// error: is the error returned by task execution.
// bool: indicates if the error - if not nil - was considered as an actual error
func (t *Task) CallAfter(fn func(string, error, bool)) {
	if t.callAfter != nil {
		t.callAfter(fn)
	}
}
```

This allows notification of state changes _after_ the task state was changed in the broker's DB:

```
func (s *serviceLackey) handleNodeEvent(ctx context.Context, task *asynq.Task) error {

	... do something ...
	task.CallAfter(func(string, error, bool) { s.notifyNodeEvent(nids, m) })
	return nil
}
```

* Unify error & delay handling such as to use same logic as task handling based on task type

The current code offers `RetryDelayFunc` and `ErrorHandler` config parameters that are global to all tasks.
The change allows to use 'mux' handlers for retry delay(s) and error handling based on the same logic that what is in use for `Handler` functions.

This would be especially useful for providing retry delays specific to task types.
