### PR TITLE
fix nil check of RetryDelayFunc

### DIFF
--- a/server.go
+++ b/server.go
@@ -329,7 +329,7 @@ func newServer(broker base.Broker, cfg Config) *Server {
 		cfg.ServerID = uuid.New().String()
 	}
 	delayFunc := cfg.RetryDelayFunc
-	if delayFunc == nil {
+	if IsNil(delayFunc) {
 		delayFunc = DefaultRetryDelay
 	}
 	isFailureFunc := cfg.IsFailure


### PR DESCRIPTION
Fix of nil check (introduced in #20): `cfg.RetryDelayFunc` is now of type `RetryDelayHandler` which is an interface.